### PR TITLE
fix role type

### DIFF
--- a/openstack/create_projects.yaml
+++ b/openstack/create_projects.yaml
@@ -46,7 +46,7 @@
         description: "Perry Johnson"
         password: "password"
         default_project: "smurf_labs"
-        default_project_role: "member"
+        default_project_role: "_member_"
         domain_id: "default"
 
   tasks:


### PR DESCRIPTION
hi Alberto,
I have noticed if I used a member-only without the fix I am getting error:
"msg": "Role member is not valid"}